### PR TITLE
Update import for tvmaze, endpoint and fuzzymatch.

### DIFF
--- a/pytvmaze/__init__.py
+++ b/pytvmaze/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/python
 
-from tvmaze import *
+from pytvmaze.tvmaze import *

--- a/pytvmaze/fuzzymatch.py
+++ b/pytvmaze/fuzzymatch.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function
 from datetime import datetime
-import tvmaze
+from pytvmaze import tvmaze
 
 WARN_MULTIPLE_RESULTS = ('\nMultiple shows matched this search, '
                 'try providing more information\nin your search such as '

--- a/pytvmaze/tvmaze.py
+++ b/pytvmaze/tvmaze.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 
 from __future__ import print_function
-import endpoints
-import fuzzymatch
+from pytvmaze import endpoints
+from pytvmaze import fuzzymatch
 
 try:
     # Python 3 and later


### PR DESCRIPTION
After installing using pip, python is complaining: `ImportError: No module named 'tvmaze'`
According to https://docs.python.org/3/tutorial/modules.html#intra-package-references,
top-level package is missing in the imports command in order to work.