### PR TITLE
Add __repr__ method for Show, Season and Episode. Update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To install:
     # Get show object
     >>> show = pytvmaze.get_show('dexter')
     >>> print(show)
-    <pytvmaze.Show instance at 0x107abefc8>
+    Dexter
     >>> print(show.name, show.status, show.maze_id)
     Dexter Ended 161
 
@@ -37,7 +37,7 @@ To install:
     # Get a specific episode with: show[season][episode]
     >>> ep = show[1][8]
     >>> print(ep)
-    <pytvmaze.Episode instance at 0x107b060e0>
+    S01E08 Shrink Wrap
     >>> print(ep.title)
     Shrink Wrap
 
@@ -87,7 +87,7 @@ There are many possible attributes of the Show class, but since TV Maze is full 
 
     ## Season object attributes ##
     season.show # the parent show object
-    season.number
+    season.season_number
     season.episodes # dict of episodes within this season
 
     ## Episode object attributes ##

--- a/pytvmaze/tvmaze.py
+++ b/pytvmaze/tvmaze.py
@@ -21,6 +21,9 @@ class Show():
         self.seasons = dict()
         self.populate()
 
+    def __repr__(self):
+        return self.name
+
     def __iter__(self):
         return iter(self.seasons.values())
 
@@ -45,6 +48,14 @@ class Season():
         self.season_number = season_number
         self.episodes = dict()
 
+    def __repr__(self):
+        if self.season_number < 10:
+            season = "S0%s"
+        else:
+            season = "S%s"
+        season %= self.season_number
+        return "%s %s" % (self.show, season)
+
     def __iter__(self):
         return iter(self.episodes.values())
 
@@ -66,6 +77,19 @@ class Episode():
         self.airstamp = self.data.get('airstamp')
         self.runtime = self.data.get('runtime')
         self.maze_id = self.data.get('id')
+
+    def __repr__(self):
+        if self.season_number < 10:
+            season = "S0%s"
+        else:
+            season = "S%s"
+        season %= self.season_number
+        if self.episode_number < 10:
+            episode = "E0%s"
+        else:
+            episode = "E%s"
+        episode %= self.episode_number
+        return "%s%s %s" %(season, episode, self.title)
 
 # Query TV Maze endpoints
 def query(url):


### PR DESCRIPTION
__repr__ allows to give a printable representation of an object.
It gives an overview of what it represents and a pretty print.

```python
> import pytvmaze
> show = pytvmaze.get_show('dexter')
> print(show)
Dexter
> print(show[1])
Dexter S01
> print(show[1][8])
S01E08 Shrink Wrap
```