### PR TITLE
`get_show_list` must returns a list in anycase.

### DIFF
--- a/pytvmaze/tvmaze.py
+++ b/pytvmaze/tvmaze.py
@@ -126,6 +126,7 @@ def get_show_list(name):
             Show(show_main_info(show['show']['id'], embed='episodes'))
             for show in shows
         ]
+    return []
 
 def get_people(name):
     people = people_search(name)


### PR DESCRIPTION
For consistency and usage when can't found any shows, return an empty list.

A good example is:
```python
for show in pytvmaze.get_show_list('thisdoesntexist'):
    print(show)

thisdoesntexist not found
```
instead of:
```python
for show in pytvmaze.get_show_list('thisdoesntexist'):
    print(show)

thisdoesntexist not found
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-749ed5ac5540> in <module>()
----> 1 for show in pytvmaze.get_show_list('thisdoesntexist'):
      2     print(show)
      3 

TypeError: 'NoneType' object is not iterable
```

It is something I have put in my previous PR #9 but I have missed it when we reworked the code and we removed it.