### PR TITLE
Encode show name to UTF-8 for proper URL encoding

### DIFF
--- a/pytvmaze/tvmaze.py
+++ b/pytvmaze/tvmaze.py
@@ -286,9 +286,9 @@ def _get_show_with_qualifiers(show_name, qualifiers):
         else:
             network = None
         if show.webChannel:
-            webChannel = show.webChannel['name'].lower()
+            web_channel = show.webChannel['name'].lower()
         else:
-            webChannel = None
+            web_channel = None
         if show.network:
             country = show.network['country']['code'].lower()
         else:
@@ -301,7 +301,7 @@ def _get_show_with_qualifiers(show_name, qualifiers):
         else:
             language = None
 
-        attributes = [premiered, country, network, language, webChannel]
+        attributes = [premiered, country, network, language, web_channel]
         show_score = len(set(qualifiers) & set(attributes))
         if show_score > best_match:
             best_match = show_score
@@ -329,21 +329,25 @@ def _url_quote(show):
 
 # Return list of Show objects
 def get_show_list(show_name):
-    '''
+    """
     Return list of Show objects from the TVMaze "Show Search" endpoint
 
     List will be ordered by tvmaze score and should mimic the results you see
     by doing a show search on the website.
-    '''
+    :param show_name: Name of show
+    :return: List of Show(s)
+    """
     shows = show_search(show_name)
     return [Show(show['show']) for show in shows]
 
 
 # Get list of Person objects
 def get_people(name):
-    '''
+    """
     Return list of Person objects from the TVMaze "People Search" endpoint
-    '''
+    :param name: Name of person
+    :return: List of Person(s)
+    """
     people = people_search(name)
     if people:
         return [Person(person) for person in people]

--- a/pytvmaze/tvmaze.py
+++ b/pytvmaze/tvmaze.py
@@ -41,7 +41,7 @@ class Show(object):
         self.image = self.data.get('image')
         self.externals = self.data.get('externals')
         self.premiered = self.data.get('premiered')
-        self.summary = self.remove_tags(self.data.get('summary'))
+        self.summary = _remove_tags(self.data.get('summary'))
         self._links = self.data.get('_links')
         self.webChannel = self.data.get('webChannel')
         self.runtime = self.data.get('runtime')
@@ -110,9 +110,6 @@ class Show(object):
                     self.cast.append(Person(cast_member['person']))
                     self.characters.append(Character(cast_member['character']))
 
-    def remove_tags(self, text):
-        return re.sub(r'<.*?>', '', text)
-
 
 class Season(object):
     def __init__(self, show, season_number):
@@ -154,6 +151,7 @@ class Episode(object):
         self.image = self.data.get('image')
         self.airstamp = self.data.get('airstamp')
         self.runtime = self.data.get('runtime')
+        self.summary = _remove_tags(self.data.get('summary'))
         self.maze_id = self.data.get('id')
 
     def __repr__(self):
@@ -210,6 +208,10 @@ class Character(object):
 
     def __str__(self):
         return self.name
+
+
+def _remove_tags(text):
+    return re.sub(r'<.*?>', '', text)
 
 
 # Query TV Maze endpoints

--- a/pytvmaze/tvmaze.py
+++ b/pytvmaze/tvmaze.py
@@ -257,13 +257,11 @@ def get_show(maze_id=None, tvdb_id=None, tvrage_id=None, show_name=None,
     :return:
     """
     if maze_id:
-        return Show(show_main_info(maze_id, embed=embed))
+        return show_main_info(maze_id, embed=embed)
     elif tvdb_id:
-        return Show(show_main_info(lookup_tvdb(tvdb_id)['id'],
-                                   embed=embed))
+        return show_main_info(lookup_tvdb(tvdb_id)['id'], embed=embed)
     elif tvrage_id:
-        return Show(show_main_info(lookup_tvrage(tvrage_id)['id'],
-                                   embed=embed))
+        return show_main_info(lookup_tvrage(tvrage_id)['id'], embed=embed)
     elif show_name:
         show = get_show_by_search(show_name, show_year, show_network,
                                   show_language, show_country, show_web_channel, embed=embed)
@@ -318,9 +316,10 @@ def get_show_by_search(show_name, show_year, show_network, show_language, show_c
         # Return show with highest tvmaze search score
         show = shows[0]
     if embed:
-        return show_single_search(show.name, embed=embed)
+        return show_main_info(maze_id=show.id, embed=embed)
     else:
         return show
+
 
 def _url_quote(show):
     return url_quote(show.encode('UTF-8'))
@@ -416,7 +415,7 @@ def show_main_info(maze_id, embed=None):
         url = endpoints.show_main_info.format(maze_id)
     q = query_endpoint(url)
     if q:
-        return q
+        return Show(q)
     else:
         raise IDNotFound('Maze id ' + str(maze_id) + ' not found')
 

--- a/pytvmaze/tvmaze.py
+++ b/pytvmaze/tvmaze.py
@@ -328,10 +328,7 @@ def get_show_list(show_name, embed=None):
     by doing a show search on the website.
     '''
     shows = show_search(show_name)
-    return [
-        Show(show_main_info(show['show']['id'], embed=embed))
-        for show in shows
-        ]
+    return [Show(show['show']['id']) for show in shows]
 
 
 # Get list of Person objects
@@ -345,9 +342,12 @@ def get_people(name):
 
 
 # TV Maze Endpoints
-def show_search(show):
+def show_search(show, embed=None):
     show = url_quote(show)
-    url = endpoints.show_search.format(show)
+    if embed:
+        url = endpoints.show_search.format(show) + '&embed=' + embed
+    else:
+        url = endpoints.show_search.format(show)
     q = query_endpoint(url)
     if q:
         return q

--- a/pytvmaze/tvmaze.py
+++ b/pytvmaze/tvmaze.py
@@ -328,7 +328,7 @@ def get_show_list(show_name, embed=None):
     by doing a show search on the website.
     '''
     shows = show_search(show_name)
-    return [Show(show['show']['id']) for show in shows]
+    return [Show(show['show']) for show in shows]
 
 
 # Get list of Person objects

--- a/test/test_tvmaze.py
+++ b/test/test_tvmaze.py
@@ -15,16 +15,16 @@ class EndpointTests(unittest.TestCase):
             show_search('abcdefg')
 
     def test_show_single_search(self):
-        show1 = show_single_search('bobs burgers')
-        self.assertIsInstance(show1, dict)
+        show1 = show_single_search(show='bobs burgers')
+        self.assertIsInstance(show1, Show)
 
-        show2 = show_single_search('extant', embed='episodes')
-        self.assertIsInstance(show2, dict)
-        self.assertIn('episodes', show2['_embedded'].keys())
+        show2 = show_single_search(show='extant', embed='episodes')
+        self.assertIsInstance(show2, Show)
+        self.assertTrue(show2.episodes)
 
-        show3 = show_single_search('archer', embed='cast')
-        self.assertIsInstance(show3, dict)
-        self.assertIn('cast', show3['_embedded'].keys())
+        show3 = show_single_search(show='archer', embed='cast')
+        self.assertIsInstance(show3, Show)
+        self.assertTrue(show3.cast)
 
         with self.assertRaises(ShowNotFound):
             show_single_search('show that doesnt exist')
@@ -61,12 +61,12 @@ class EndpointTests(unittest.TestCase):
         self.assertIsInstance(schedule, list)
 
     def test_show_main_info(self):
-        show1 = show_main_info(1)
-        self.assertIsInstance(show1, dict)
+        show1 = show_main_info(maze_id=1)
+        self.assertIsInstance(show1, Show)
 
-        show2 = show_main_info(2, embed='episodes')
-        self.assertIsInstance(show2, dict)
-        self.assertIn('episodes', show2['_embedded'].keys())
+        show2 = show_main_info(maze_id=2, embed='episodes')
+        self.assertIsInstance(show2, Show)
+        self.assertTrue(show2.episodes)
 
         with self.assertRaises(IDNotFound):
             show_main_info(9999999999)


### PR DESCRIPTION
Encode show name to UTF-8 for proper URL encoding and removed redundant API calls for show search by name.

I made a little mess with the commit order and labeling but the content is fine and the tests pass. This improves performance tremendously.

Made a lot of changes with this but performance is amazing, since it doesn't do redundant API calls for each show in show_list. if embedding is not required it's even faster.