### PR TITLE
Fix bug in Show creation when summary is not available

### DIFF
--- a/pytvmaze/tvmaze.py
+++ b/pytvmaze/tvmaze.py
@@ -24,7 +24,7 @@ class Show(object):
         self.image = data.get('image')
         self.externals = data.get('externals')
         self.premiered = data.get('premiered')
-        self.summary = _remove_tags(data.get('summary'))
+        self.summary = _remove_tags(data.get('summary', ''))
         self.links = data.get('_links')
         if data.get('webChannel'):
             self.web_channel = WebChannel(data.get('webChannel'))


### PR DESCRIPTION
`_remove_tags` cannot operate on None values, it needs a string.